### PR TITLE
Add DNS concurrency throttling and settings control

### DIFF
--- a/src/locales/en-US/common.json
+++ b/src/locales/en-US/common.json
@@ -162,6 +162,8 @@
   "page.export.settings.providerError": "Keep at least one provider active.",
   "page.export.settings.rdapConcurrency": "RDAP concurrency",
   "page.export.settings.rdapHelper": "Current value: {{value}} request(s) at a time.",
+  "page.export.settings.dnsConcurrency": "DNS concurrency",
+  "page.export.settings.dnsHelper": "Current value: {{value}} DNS lookups in parallel.",
   "page.export.settings.proxy": "Route requests through proxy",
   "page.export.settings.whois": "Enable WHOIS fallback when RDAP is unsupported",
   "page.export.sidebar.title": "Session overview",

--- a/src/locales/zh-Hans/common.json
+++ b/src/locales/zh-Hans/common.json
@@ -162,6 +162,8 @@
   "page.export.settings.providerError": "至少保留一个提供商。",
   "page.export.settings.rdapConcurrency": "RDAP 并发数",
   "page.export.settings.rdapHelper": "当前值：同时 {{value}} 个请求。",
+  "page.export.settings.dnsConcurrency": "DNS 并发数",
+  "page.export.settings.dnsHelper": "当前值：同时 {{value}} 个 DNS 查询。",
   "page.export.settings.proxy": "通过代理转发请求",
   "page.export.settings.whois": "RDAP 不支持时启用 WHOIS 兜底",
   "page.export.sidebar.title": "会话概览",

--- a/src/pages/DnsPage.tsx
+++ b/src/pages/DnsPage.tsx
@@ -7,13 +7,14 @@ import Paper from "@mui/material/Paper";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import { DataGrid, type GridColDef } from "@mui/x-data-grid";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { alpha } from "@mui/material/styles";
 
 import { StatsCard, HintCard } from "../components/SidebarCards";
 import { useWideShellSidebar } from "../layouts/WideShell";
 import { useAppDispatch, useAppState } from "../shared/hooks/useAppState";
+import { useConcurrentQueue } from "../shared/hooks/useConcurrentQueue";
 import type { DomainCheckRow } from "../shared/types";
 import { buildCsvContent, downloadCsv } from "../shared/utils/csv";
 import { runDohQuery } from "../shared/utils/dohQuery";
@@ -31,6 +32,10 @@ export default function DnsPage() {
   const { t } = useTranslation();
   const { input, dns, settings } = useAppState();
   const dispatch = useAppDispatch();
+  const { enqueue, clear } = useConcurrentQueue(settings.dnsConcurrency);
+
+  // 卸载时清理并发队列，避免残留任务
+  useEffect(() => clear, [clear]);
   const progressValue = useMemo(() => {
     if (dns.totalCount === 0) {
       return 0;
@@ -208,42 +213,44 @@ export default function DnsPage() {
     });
 
     try {
-      // 使用 Promise.all 并行执行 DoH 查询，加快批量处理速度
+      // 使用受限并发执行 DoH 查询，避免瞬时请求过多
       const nextRows: DomainCheckRow[] = new Array(baseRows.length);
       let completed = 0;
       await Promise.all(
-        baseRows.map(async (row, index) => {
-          try {
-            const result = await runDohQuery(row.ascii, settings.dohProviders);
-            const providerLabel = result.provider
-              ? t(`dns.provider.${result.provider}`)
-              : t("dns.provider.unknown");
-            const detailText = mergeDetails(
-              result.detail ? t(result.detail) : undefined,
-              t("dns.detail.source", { provider: providerLabel })
-            );
+        baseRows.map((row, index) =>
+          enqueue(async () => {
+            try {
+              const result = await runDohQuery(row.ascii, settings.dohProviders);
+              const providerLabel = result.provider
+                ? t(`dns.provider.${result.provider}`)
+                : t("dns.provider.unknown");
+              const detailText = mergeDetails(
+                result.detail ? t(result.detail) : undefined,
+                t("dns.detail.source", { provider: providerLabel })
+              );
 
-            const dnsStatus = result.status;
-            nextRows[index] = {
-              ...row,
-              dns: dnsStatus,
-              verdict: deriveDnsVerdict(dnsStatus),
-              detail: detailText
-            };
-          } catch (error) {
-            console.error("runDohQuery error", error);
-            nextRows[index] = {
-              ...row,
-              dns: "error" as const,
-              verdict: "undetermined" as const,
-              detail: t("dns.detail.network-error")
-            };
-          } finally {
-            // 记录已完成数量并同步到全局状态，驱动进度条
-            completed += 1;
-            dispatch({ type: "dns/progress", payload: { runId, completed } });
-          }
-        })
+              const dnsStatus = result.status;
+              nextRows[index] = {
+                ...row,
+                dns: dnsStatus,
+                verdict: deriveDnsVerdict(dnsStatus),
+                detail: detailText
+              };
+            } catch (error) {
+              console.error("runDohQuery error", error);
+              nextRows[index] = {
+                ...row,
+                dns: "error" as const,
+                verdict: "undetermined" as const,
+                detail: t("dns.detail.network-error")
+              };
+            } finally {
+              // 记录已完成数量并同步到全局状态，驱动进度条
+              completed += 1;
+              dispatch({ type: "dns/progress", payload: { runId, completed } });
+            }
+          })
+        )
       );
 
       dispatch({ type: "dns/success", payload: { rows: nextRows, runId } });
@@ -265,7 +272,7 @@ export default function DnsPage() {
         payload: { severity: "error", messageKey: "dns.error.general" }
       });
     }
-  }, [dispatch, input.domains, settings.dohProviders, t]);
+  }, [dispatch, enqueue, input.domains, settings.dohProviders, t]);
 
   return (
     <Stack spacing={3}>

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -24,6 +24,11 @@ import type { DohProviderId } from "../shared/types";
 //
 
 const PROVIDER_ORDER: DohProviderId[] = ["google", "cloudflare"]; // 展示顺序固定
+const DNS_CONCURRENCY_MARKS = [
+  { value: 200, label: "200" },
+  { value: 1000, label: "1000" },
+  { value: 5000, label: "5000" }
+];
 
 /**
  * 设置页，提供运行参数配置。
@@ -56,10 +61,19 @@ export default function SettingsPage() {
   );
 
   // RDAP 并发滑块
-  const handleConcurrencyChange = useCallback(
+  const handleRdapConcurrencyChange = useCallback(
     (_event: Event, value: number | number[]) => {
       const nextValue = Array.isArray(value) ? value[0] : value;
       dispatch({ type: "settings/update", payload: { rdapConcurrency: nextValue } });
+    },
+    [dispatch]
+  );
+
+  // DNS 并发滑块
+  const handleDnsConcurrencyChange = useCallback(
+    (_event: Event, value: number | number[]) => {
+      const nextValue = Array.isArray(value) ? value[0] : value;
+      dispatch({ type: "settings/update", payload: { dnsConcurrency: nextValue } });
     },
     [dispatch]
   );
@@ -84,6 +98,10 @@ export default function SettingsPage() {
   const rdapHelperText = useMemo(
     () => t("page.export.settings.rdapHelper", { value: settings.rdapConcurrency }),
     [settings.rdapConcurrency, t]
+  );
+  const dnsHelperText = useMemo(
+    () => t("page.export.settings.dnsHelper", { value: settings.dnsConcurrency }),
+    [settings.dnsConcurrency, t]
   );
 
   return (
@@ -150,7 +168,27 @@ export default function SettingsPage() {
             step={1}
             marks
             valueLabelDisplay="auto"
-            onChange={handleConcurrencyChange}
+            onChange={handleRdapConcurrencyChange}
+          />
+        </Box>
+
+        <Box>
+          <Stack direction="row" justifyContent="space-between" alignItems="center">
+            <FormLabel component="legend">
+              {t("page.export.settings.dnsConcurrency")}
+            </FormLabel>
+            <Typography variant="body2" color="text.secondary">
+              {dnsHelperText}
+            </Typography>
+          </Stack>
+          <Slider
+            value={settings.dnsConcurrency}
+            min={200}
+            max={5000}
+            step={100}
+            marks={DNS_CONCURRENCY_MARKS}
+            valueLabelDisplay="auto"
+            onChange={handleDnsConcurrencyChange}
           />
         </Box>
 

--- a/src/shared/hooks/useAppState.tsx
+++ b/src/shared/hooks/useAppState.tsx
@@ -21,6 +21,7 @@ import {
 
 const defaultSettings: AppSettings = {
   rdapConcurrency: 3,
+  dnsConcurrency: 1000,
   dohProviders: ["google", "cloudflare"],
   useProxy: false,
   enableWhoisFallback: false
@@ -589,12 +590,16 @@ function sanitizeSettings(settings: AppSettings): AppSettings {
   );
 
   const safeProviders = providers.length > 0 ? providers : [...defaultSettings.dohProviders];
-  const concurrency = Number.isFinite(settings.rdapConcurrency)
+  const rdapConcurrency = Number.isFinite(settings.rdapConcurrency)
     ? Math.min(Math.max(Math.trunc(settings.rdapConcurrency), 1), 12)
     : defaultSettings.rdapConcurrency;
+  const dnsConcurrency = Number.isFinite(settings.dnsConcurrency)
+    ? Math.min(Math.max(Math.trunc(settings.dnsConcurrency), 200), 5000)
+    : defaultSettings.dnsConcurrency;
 
   return {
-    rdapConcurrency: concurrency,
+    rdapConcurrency,
+    dnsConcurrency,
     dohProviders: safeProviders,
     useProxy: Boolean(settings.useProxy),
     enableWhoisFallback: Boolean(settings.enableWhoisFallback)
@@ -607,6 +612,7 @@ function sanitizeSettings(settings: AppSettings): AppSettings {
 function areSettingsEqual(a: AppSettings, b: AppSettings): boolean {
   return (
     a.rdapConcurrency === b.rdapConcurrency &&
+    a.dnsConcurrency === b.dnsConcurrency &&
     a.useProxy === b.useProxy &&
     a.enableWhoisFallback === b.enableWhoisFallback &&
     a.dohProviders.length === b.dohProviders.length &&

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -80,6 +80,8 @@ export type DohProviderId = "google" | "cloudflare";
 export interface AppSettings {
   /** RDAP 查询最大并发数 */
   rdapConcurrency: number;
+  /** DNS 查询最大并发数 */
+  dnsConcurrency: number;
   /** DoH 查询使用的提供者顺序 */
   dohProviders: DohProviderId[];
   /** 是否通过代理中转网络请求 */


### PR DESCRIPTION
## Summary
- throttle DNS DoH pre-checks via the existing concurrent queue and respect a configurable limit
- add a DNS concurrency slider and helper text to the settings page so users can tune throughput between 200 and 5000
- persist the new DNS concurrency value in shared settings/types and provide localized strings

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dca867a5a88320b3d3ece419fa5a0e