### PR TITLE
feat: add alphabetic dictionary generation

### DIFF
--- a/src/locales/en-US/common.json
+++ b/src/locales/en-US/common.json
@@ -35,6 +35,7 @@
   "input.dict.desc": "Generate pattern-based domains. Example: 000000.xyz to 999999.xyz.",
   "input.dict.patternType": "Pattern",
   "input.dict.numericN": "Numeric (N digits)",
+  "input.dict.alphaN": "Alphabetic (random)",
   "input.dict.alnumN": "Alphanumeric (random)",
   "input.dict.template": "Custom template",
   "input.dict.length": "Length (N)",

--- a/src/locales/zh-Hans/common.json
+++ b/src/locales/zh-Hans/common.json
@@ -35,6 +35,7 @@
   "input.dict.desc": "按模式生成批量域名，例如：000000.xyz 至 999999.xyz。",
   "input.dict.patternType": "生成模式",
   "input.dict.numericN": "纯数字（固定位数）",
+  "input.dict.alphaN": "纯字母（随机）",
   "input.dict.alnumN": "字母数字混合（随机）",
   "input.dict.template": "自定义模板",
   "input.dict.length": "位数 N",


### PR DESCRIPTION
## Summary
- add an alphabetic-only option to dictionary generation with shared charset iterator
- ensure non-template dictionary patterns require a TLD and expose the new selector option
- localize the new pattern label for both zh-Hans and en-US

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e22480b05c8320880b2922802f8deb