### PR TITLE
Adjust dictionary template length handling

### DIFF
--- a/src/features/input/DictionaryTab.tsx
+++ b/src/features/input/DictionaryTab.tsx
@@ -182,14 +182,16 @@ export default function DictionaryTab() {
           </Select>
         </FormControl>
 
-        <TextField
-          type="number"
-          label={t("input.dict.length")}
-          value={length}
-          onChange={(event) => setLength(Number(event.target.value))}
-          inputProps={{ min: MIN_LENGTH, max: MAX_LENGTH }}
-          size="small"
-        />
+        {pattern !== "template" ? (
+          <TextField
+            type="number"
+            label={t("input.dict.length")}
+            value={length}
+            onChange={(event) => setLength(Number(event.target.value))}
+            inputProps={{ min: MIN_LENGTH, max: MAX_LENGTH }}
+            size="small"
+          />
+        ) : null}
 
         <TextField
           label={t("input.dict.tld")}
@@ -267,7 +269,10 @@ function validateInputs(
   tld: string,
   template: string
 ): ValidationResult {
-  if (!Number.isInteger(length) || length < MIN_LENGTH || length > MAX_LENGTH) {
+  if (
+    pattern !== "template" &&
+    (!Number.isInteger(length) || length < MIN_LENGTH || length > MAX_LENGTH)
+  ) {
     return { valid: false, errorKey: "input.dict.invalidLength" };
   }
 


### PR DESCRIPTION
## Summary
- hide the digit count input when the dictionary generator is in template mode
- skip length validation for template-based generation to avoid template errors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e226b5f1548320b5e4f94562ccdd0a