### PR TITLE
Add cancellation handling to streaming dictionary generator

### DIFF
--- a/src/features/input/DictionaryTab.tsx
+++ b/src/features/input/DictionaryTab.tsx
@@ -12,12 +12,13 @@ import Select from "@mui/material/Select";
 import Stack from "@mui/material/Stack";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { useAppDispatch, useAppState } from "../../shared/hooks/useAppState";
 import { normalizeDomains } from "../../shared/utils/domainParser";
 import { createAsciiSet, partitionByExisting, sanitizeTld } from "../../shared/utils/domains";
+import type { DomainItem } from "../../shared/types";
 
 const DIGITS = "0123456789";
 const LETTERS = "abcdefghijklmnopqrstuvwxyz";
@@ -52,12 +53,32 @@ export default function DictionaryTab() {
   const [loading, setLoading] = useState<boolean>(false);
   const [summary, setSummary] = useState<GenerationSummary | null>(null);
 
+  // 通过 runIdRef 标记最新任务，防止旧任务回调继续更新状态
+  const runIdRef = useRef(0);
+  // 记录当前预览/生成的 AbortController，便于随时取消长任务
+  const previewAbortRef = useRef<AbortController | null>(null);
+  const generateAbortRef = useRef<AbortController | null>(null);
+  const mountedRef = useRef(true);
+
   const existingAscii = useMemo(() => createAsciiSet(input.domains), [input.domains]);
 
   const handlePatternChange = useCallback((value: PatternType) => {
+    runIdRef.current += 1;
+    previewAbortRef.current?.abort();
+    generateAbortRef.current?.abort();
     setPattern(value);
     setPreview([]);
     setSummary(null);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    // 组件卸载时立即终止仍在运行的生成任务，避免内存泄露
+    return () => {
+      mountedRef.current = false;
+      previewAbortRef.current?.abort();
+      generateAbortRef.current?.abort();
+    };
   }, []);
 
   const handlePreview = useCallback(async () => {
@@ -70,28 +91,58 @@ export default function DictionaryTab() {
       return;
     }
 
-    setLoading(true);
+    const runId = runIdRef.current + 1;
+    runIdRef.current = runId;
+
+    previewAbortRef.current?.abort();
+    const controller = new AbortController();
+    previewAbortRef.current = controller;
+
     setSummary(null);
+    setPreview([]);
+    setLoading(true);
     try {
       const sanitizedTld = sanitizeTld(tld);
-      const domains = await generateDomains(
+      const generator = generateDomains(
         {
           pattern,
           length,
           template,
           tld: sanitizedTld
         },
-        PREVIEW_COUNT
+        {
+          limit: PREVIEW_COUNT,
+          signal: controller.signal
+        }
       );
-      setPreview(domains.slice(0, PREVIEW_COUNT));
+
+      const collected: string[] = [];
+      for await (const batch of generator) {
+        if (controller.signal.aborted || runIdRef.current !== runId || !mountedRef.current) {
+          break;
+        }
+        collected.push(...batch);
+        if (collected.length >= PREVIEW_COUNT) {
+          break;
+        }
+      }
+
+      if (!controller.signal.aborted && runIdRef.current === runId && mountedRef.current) {
+        setPreview(collected.slice(0, PREVIEW_COUNT));
+      }
     } catch (error) {
+      if (controller.signal.aborted || runIdRef.current !== runId || !mountedRef.current) {
+        return;
+      }
       console.error("dictionary preview failed", error);
       dispatch({
         type: "ui/snackbar",
         payload: { severity: "error", messageKey: "input.dict.previewFailed" }
       });
     } finally {
-      setLoading(false);
+      if (runIdRef.current === runId && mountedRef.current) {
+        setLoading(false);
+      }
     }
   }, [dispatch, length, pattern, tld, template]);
 
@@ -105,59 +156,122 @@ export default function DictionaryTab() {
       return;
     }
 
+    const runId = runIdRef.current + 1;
+    runIdRef.current = runId;
+
+    generateAbortRef.current?.abort();
+    const controller = new AbortController();
+    generateAbortRef.current = controller;
+
     setLoading(true);
+    setSummary(null);
     try {
       const sanitizedTld = sanitizeTld(tld);
-      const domains = await generateDomains({
-        pattern,
-        length,
-        template,
-        tld: sanitizedTld
-      });
+      const generator = generateDomains(
+        {
+          pattern,
+          length,
+          template,
+          tld: sanitizedTld
+        },
+        { signal: controller.signal }
+      );
 
-      const { valid, invalid, duplicate } = normalizeDomains(domains);
-      const { fresh, duplicate: existingDuplicate } = partitionByExisting(valid, existingAscii);
+      const aggregated: GenerationSummary = {
+        generated: 0,
+        added: 0,
+        duplicated: 0,
+        invalid: 0,
+        existing: 0
+      };
+      const existingTracker = new Set(existingAscii);
+      const generatedAscii = new Set<string>();
 
-      if (fresh.length === 0) {
+      for await (const batch of generator) {
+        if (controller.signal.aborted || runIdRef.current !== runId || !mountedRef.current) {
+          break;
+        }
+        aggregated.generated += batch.length;
+        if (batch.length === 0) {
+          continue;
+        }
+
+        const { valid, invalid, duplicate } = normalizeDomains(batch);
+        aggregated.invalid += invalid.length;
+        aggregated.duplicated += duplicate.length;
+
+        const uniqueValid: DomainItem[] = [];
+        for (const domain of valid) {
+          if (generatedAscii.has(domain.ascii)) {
+            aggregated.duplicated += 1;
+            continue;
+          }
+
+          generatedAscii.add(domain.ascii);
+          uniqueValid.push(domain);
+        }
+
+        if (uniqueValid.length === 0) {
+          if (!controller.signal.aborted && runIdRef.current === runId && mountedRef.current) {
+            setSummary({ ...aggregated });
+          }
+          continue;
+        }
+
+        const { fresh, duplicate: existingDuplicate } = partitionByExisting(uniqueValid, existingTracker);
+        aggregated.existing += existingDuplicate.length;
+
+        if (fresh.length > 0) {
+          for (const item of fresh) {
+            existingTracker.add(item.ascii);
+          }
+
+          aggregated.added += fresh.length;
+          if (!controller.signal.aborted && runIdRef.current === runId && mountedRef.current) {
+            dispatch({ type: "input/appendDomainBatch", payload: { domains: fresh } });
+          }
+        }
+
+        if (!controller.signal.aborted && runIdRef.current === runId && mountedRef.current) {
+          setSummary({ ...aggregated });
+        }
+      }
+
+      if (controller.signal.aborted || runIdRef.current !== runId || !mountedRef.current) {
+        return;
+      }
+
+      setSummary({ ...aggregated });
+
+      if (aggregated.added === 0) {
         dispatch({
           type: "ui/snackbar",
           payload: { severity: "info", messageKey: "input.dict.noNew" }
         });
-        setSummary({
-          generated: domains.length,
-          added: 0,
-          duplicated: duplicate.length,
-          invalid: invalid.length,
-          existing: existingDuplicate.length
-        });
         return;
       }
 
-      dispatch({ type: "input/appendDomains", payload: { domains: fresh } });
       dispatch({
         type: "ui/snackbar",
         payload: {
           severity: "success",
           messageKey: "input.dict.added",
-          messageParams: { count: fresh.length }
+          messageParams: { count: aggregated.added }
         }
       });
-
-      setSummary({
-        generated: domains.length,
-        added: fresh.length,
-        duplicated: duplicate.length,
-        invalid: invalid.length,
-        existing: existingDuplicate.length
-      });
     } catch (error) {
+      if (controller.signal.aborted || runIdRef.current !== runId || !mountedRef.current) {
+        return;
+      }
       console.error("dictionary generation failed", error);
       dispatch({
         type: "ui/snackbar",
         payload: { severity: "error", messageKey: "input.dict.generateFailed" }
       });
     } finally {
-      setLoading(false);
+      if (runIdRef.current === runId && mountedRef.current) {
+        setLoading(false);
+      }
     }
   }, [dispatch, existingAscii, length, pattern, tld, template]);
 
@@ -259,6 +373,11 @@ interface GenerateParams {
   tld: string;
 }
 
+interface GenerateOptions {
+  limit?: number;
+  signal?: AbortSignal;
+}
+
 type ValidationResult = { valid: true } | { valid: false; errorKey: string };
 
 function validateInputs(
@@ -287,97 +406,202 @@ function validateInputs(
   return { valid: true };
 }
 
-async function generateDomains(
+/**
+ * 根据用户选择的模式生成域名，支持批量迭代与外部取消。
+ * @param params 生成配置（模式、长度、模板、TLD）
+ * @param options 生成限制与取消信号
+ */
+async function* generateDomains(
   { pattern, length, template, tld }: GenerateParams,
-  limit?: number
-): Promise<string[]> {
+  options: GenerateOptions = {}
+): AsyncGenerator<string[]> {
+  const { limit, signal } = options;
   switch (pattern) {
     case "numeric":
-      return generateNumeric(length, tld, limit);
+      yield* generateNumeric(length, tld, limit, signal);
+      return;
     case "alpha":
-      return generateAlpha(length, tld, limit);
+      yield* generateAlpha(length, tld, limit, signal);
+      return;
     case "alnum":
-      return generateAlnum(length, tld, limit);
+      yield* generateAlnum(length, tld, limit, signal);
+      return;
     case "template":
-      return generateFromTemplate(template, tld, limit);
+      yield* generateFromTemplate(template, tld, limit, signal);
+      return;
     default:
-      return [];
+      return;
   }
 }
 
-async function generateNumeric(length: number, tld: string, limit?: number): Promise<string[]> {
+/**
+ * 生成固定长度的纯数字域名。
+ * @param length 数字串长度
+ * @param tld 顶级域
+ * @param limit 可选的最大生成数量
+ * @param signal 取消信号
+ */
+async function* generateNumeric(
+  length: number,
+  tld: string,
+  limit?: number,
+  signal?: AbortSignal
+): AsyncGenerator<string[]> {
+  if (length <= 0 || signal?.aborted) {
+    return;
+  }
+
   const maxCombinations = Math.pow(10, length);
   const total = limit === undefined ? maxCombinations : Math.min(limit, maxCombinations);
-  const result: string[] = [];
   const batchSize = 2000;
 
   for (let start = 0; start < total; start += batchSize) {
+    if (signal?.aborted) {
+      return;
+    }
     const end = Math.min(start + batchSize, total);
+    const batch: string[] = [];
     for (let value = start; value < end; value += 1) {
+      if (signal?.aborted) {
+        return;
+      }
       const label = value.toString().padStart(length, "0");
-      result.push(applyTld(label, tld));
+      batch.push(applyTld(label, tld));
+    }
+
+    if (signal?.aborted) {
+      return;
+    }
+
+    if (batch.length > 0) {
+      yield batch;
     }
 
     // 分批让出主线程
     if (end < total) {
-      await delay();
+      await delay(signal);
     }
   }
-
-  return result;
 }
 
-async function generateAlpha(length: number, tld: string, limit?: number): Promise<string[]> {
-  return generateByCharset(LETTER_CHARSET, length, tld, limit);
+/**
+ * 基于字母字符集生成域名。
+ * @param length 域名长度
+ * @param tld 顶级域
+ * @param limit 可选的最大生成数量
+ * @param signal 取消信号
+ */
+async function* generateAlpha(
+  length: number,
+  tld: string,
+  limit?: number,
+  signal?: AbortSignal
+): AsyncGenerator<string[]> {
+  yield* generateByCharset(LETTER_CHARSET, length, tld, limit, signal);
 }
 
-async function generateAlnum(length: number, tld: string, limit?: number): Promise<string[]> {
-  return generateByCharset(ALNUM_CHARSET, length, tld, limit);
+/**
+ * 基于字母与数字混合字符集生成域名。
+ * @param length 域名长度
+ * @param tld 顶级域
+ * @param limit 可选的最大生成数量
+ * @param signal 取消信号
+ */
+async function* generateAlnum(
+  length: number,
+  tld: string,
+  limit?: number,
+  signal?: AbortSignal
+): AsyncGenerator<string[]> {
+  yield* generateByCharset(ALNUM_CHARSET, length, tld, limit, signal);
 }
 
-async function generateByCharset(
+/**
+ * 通过计数器枚举指定字符集的所有组合。
+ * @param charset 可用字符集合
+ * @param length 域名长度
+ * @param tld 顶级域
+ * @param limit 可选的最大生成数量
+ * @param signal 取消信号
+ */
+async function* generateByCharset(
   charset: string[],
   length: number,
   tld: string,
-  limit?: number
-): Promise<string[]> {
-  if (length <= 0) {
-    return [];
+  limit?: number,
+  signal?: AbortSignal
+): AsyncGenerator<string[]> {
+  if (length <= 0 || signal?.aborted) {
+    return;
   }
 
-  const result: string[] = [];
   const counters = new Array(length).fill(0);
   const maxIterations = limit ?? Number.POSITIVE_INFINITY;
+  const batchSize = 2000;
+  let generated = 0;
+  let exhausted = false;
 
   // 使用计数器逐位枚举给定字符集的笛卡尔积，保证生成顺序稳定
-  for (let generated = 0; generated < maxIterations; generated += 1) {
-    const label = counters.map((index) => charset[index]).join("");
-    result.push(applyTld(label, tld));
+  while (!exhausted && generated < maxIterations) {
+    if (signal?.aborted) {
+      return;
+    }
+    const batch: string[] = [];
 
-    let pointer = length - 1;
-    while (pointer >= 0) {
-      counters[pointer] += 1;
-      if (counters[pointer] < charset.length) {
-        break;
+    while (batch.length < batchSize && generated < maxIterations && !exhausted) {
+      if (signal?.aborted) {
+        return;
+      }
+      const label = counters.map((index) => charset[index]).join("");
+      batch.push(applyTld(label, tld));
+      generated += 1;
+
+      let pointer = length - 1;
+      while (pointer >= 0) {
+        counters[pointer] += 1;
+        if (counters[pointer] < charset.length) {
+          break;
+        }
+
+        counters[pointer] = 0;
+        pointer -= 1;
       }
 
-      counters[pointer] = 0;
-      pointer -= 1;
+      if (pointer < 0) {
+        exhausted = true;
+      }
     }
 
-    if (pointer < 0) {
-      break;
+    if (signal?.aborted) {
+      return;
     }
 
-    if ((generated + 1) % 2000 === 0) {
-      await delay();
+    if (batch.length > 0) {
+      yield batch;
+    }
+
+    if (!exhausted && generated < maxIterations) {
+      await delay(signal);
     }
   }
-
-  return result;
 }
 
-async function generateFromTemplate(template: string, tld: string, limit?: number): Promise<string[]> {
+/**
+ * 基于模板占位符逐批生成域名。
+ * @param template 模板字符串
+ * @param tld 顶级域
+ * @param limit 可选的最大生成数量
+ * @param signal 取消信号
+ */
+async function* generateFromTemplate(
+  template: string,
+  tld: string,
+  limit?: number,
+  signal?: AbortSignal
+): AsyncGenerator<string[]> {
+  if (signal?.aborted) {
+    return;
+  }
   const tokens = parseTemplate(template);
   if (!tokens.valid) {
     throw new Error("invalid-template");
@@ -385,55 +609,74 @@ async function generateFromTemplate(template: string, tld: string, limit?: numbe
 
   const placeholders = tokens.placeholders;
   if (placeholders.length === 0) {
-    return [applyTld(template, tld)];
+    if (signal?.aborted) {
+      return;
+    }
+    yield [applyTld(template, tld)];
+    return;
   }
 
   const lengths = placeholders.map((set) => set.length);
   const counters = new Array(placeholders.length).fill(0);
-  const result: string[] = [];
   const maxIterations = limit ?? Number.POSITIVE_INFINITY;
+  const batchSize = 2000;
+  let generated = 0;
+  let exhausted = false;
 
-  for (let generated = 0; generated < maxIterations; generated += 1) {
-    const parts: string[] = [];
-    let placeholderIndex = 0;
+  while (!exhausted && generated < maxIterations) {
+    if (signal?.aborted) {
+      return;
+    }
+    const batch: string[] = [];
 
-    for (const token of tokens.tokens) {
-      if (token.type === "literal") {
-        parts.push(token.value);
-        continue;
+    while (batch.length < batchSize && generated < maxIterations && !exhausted) {
+      if (signal?.aborted) {
+        return;
+      }
+      const parts: string[] = [];
+      let placeholderIndex = 0;
+
+      for (const token of tokens.tokens) {
+        if (token.type === "literal") {
+          parts.push(token.value);
+          continue;
+        }
+
+        parts.push(placeholders[placeholderIndex][counters[placeholderIndex]]);
+        placeholderIndex += 1;
       }
 
-      parts.push(placeholders[placeholderIndex][counters[placeholderIndex]]);
-      placeholderIndex += 1;
-    }
+      batch.push(applyTld(parts.join(""), tld));
+      generated += 1;
 
-    result.push(applyTld(parts.join(""), tld));
+      let pointer = counters.length - 1;
+      while (pointer >= 0) {
+        counters[pointer] += 1;
+        if (counters[pointer] < lengths[pointer]) {
+          break;
+        }
 
-    if (generated + 1 >= maxIterations) {
-      break;
-    }
-
-    let pointer = counters.length - 1;
-    while (pointer >= 0) {
-      counters[pointer] += 1;
-      if (counters[pointer] < lengths[pointer]) {
-        break;
+        counters[pointer] = 0;
+        pointer -= 1;
       }
 
-      counters[pointer] = 0;
-      pointer -= 1;
+      if (pointer < 0) {
+        exhausted = true;
+      }
     }
 
-    if (pointer < 0) {
-      break;
+    if (signal?.aborted) {
+      return;
     }
 
-    if ((generated + 1) % 2000 === 0) {
-      await delay();
+    if (batch.length > 0) {
+      yield batch;
+    }
+
+    if (!exhausted && generated < maxIterations) {
+      await delay(signal);
     }
   }
-
-  return result;
 }
 
 function applyTld(label: string, tld: string): string {
@@ -511,8 +754,33 @@ function resolveCharset(token: string): string[] | null {
   }
 }
 
-function delay(): Promise<void> {
+/**
+ * 让出事件循环，避免阻塞主线程，支持取消。
+ * @param signal 取消信号
+ */
+function delay(signal?: AbortSignal): Promise<void> {
+  if (!signal) {
+    return new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+  }
+
+  if (signal.aborted) {
+    return Promise.resolve();
+  }
+
   return new Promise((resolve) => {
-    setTimeout(resolve, 0);
+    const handleAbort = () => {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", handleAbort);
+      resolve();
+    };
+
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", handleAbort);
+      resolve();
+    }, 0);
+
+    signal.addEventListener("abort", handleAbort, { once: true });
   });
 }

--- a/src/shared/hooks/useAppState.tsx
+++ b/src/shared/hooks/useAppState.tsx
@@ -227,7 +227,8 @@ function createReducer(): (state: AppState, action: AppAction) => AppState {
           }
         } satisfies AppState;
       }
-      case "input/appendDomains": {
+      case "input/appendDomains":
+      case "input/appendDomainBatch": {
         const { domains: merged, added } = mergeDomains(state.input.domains, action.payload.domains);
         if (added === 0) {
           return state;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -225,6 +225,7 @@ export interface AppState {
 export type AppAction =
   | { type: "input/setDomains"; payload: { domains: DomainItem[] } }
   | { type: "input/appendDomains"; payload: { domains: DomainItem[] } }
+  | { type: "input/appendDomainBatch"; payload: { domains: DomainItem[] } }
   | { type: "input/clear" }
   | { type: "dns/start"; payload: { runId: number; total: number } }
   | { type: "dns/retry"; payload: { runId: number; total: number } }


### PR DESCRIPTION
## Summary
- guard dictionary streaming runs with abort controllers and run ids so cancelled preview/generate tasks stop updating state and reset loading
- allow dictionary AsyncGenerator helpers to accept abort signals, stopping batch yields promptly and documenting the new behavior

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e22702efb0832099ae68d5f64dad5b