### PR TITLE
Stream dictionary domain generation in batches

### DIFF
--- a/src/locales/en-US/common.json
+++ b/src/locales/en-US/common.json
@@ -43,6 +43,8 @@
   "input.dict.templateLabel": "Template pattern",
   "input.dict.templateHint": "Use {n} for digits, {a} for letters, {al} for alphanumeric. Example: aa{n}{n}{n}.",
   "input.dict.summary": "Generated {{generated}} · Added {{added}} · Duplicates {{duplicate}} · Invalid {{invalid}}",
+  "input.dict.progress": "Processed {{generated}} domains...",
+  "input.dict.progressWithTotal": "Processed {{generated}} / {{total}} domains...",
   "input.dict.previewTitle": "Preview (first {{count}})",
   "input.dict.invalidLength": "Length must be between 1 and 63.",
   "input.dict.invalidTld": "Provide a valid TLD (e.g. com or xyz).",

--- a/src/locales/zh-Hans/common.json
+++ b/src/locales/zh-Hans/common.json
@@ -43,6 +43,8 @@
   "input.dict.templateLabel": "模板内容",
   "input.dict.templateHint": "占位符：{n} 数字、{a} 字母、{al} 字母数字。例如 aa{n}{n}{n}。",
   "input.dict.summary": "生成 {{generated}} 条 · 新增 {{added}} 条 · 重复 {{duplicate}} 条 · 无效 {{invalid}} 条",
+  "input.dict.progress": "已处理 {{generated}} 条域名……",
+  "input.dict.progressWithTotal": "已处理 {{generated}} / {{total}} 条域名……",
   "input.dict.previewTitle": "预览（前 {{count}} 条）",
   "input.dict.invalidLength": "位数需在 1~63 之间。",
   "input.dict.invalidTld": "请输入合法的顶级域（如 com 或 xyz）。",

--- a/src/shared/hooks/useAppState.tsx
+++ b/src/shared/hooks/useAppState.tsx
@@ -257,6 +257,41 @@ function createReducer(): (state: AppState, action: AppAction) => AppState {
           }
         } satisfies AppState;
       }
+      case "input/appendDomainBatch": {
+        const { domains: merged, added } = mergeDomains(state.input.domains, action.payload.domains);
+        if (added === 0) {
+          return state;
+        }
+
+        return {
+          ...state,
+          input: {
+            domains: merged,
+            updatedAt: Date.now()
+          }
+        } satisfies AppState;
+      }
+      case "input/appendDomainBatchFinalize": {
+        return {
+          ...state,
+          dns: {
+            ...state.dns,
+            stage: "idle",
+            rows: [],
+            errorKey: null,
+            runId: state.dns.runId + 1,
+            completedAt: null,
+            totalCount: 0,
+            completedCount: 0
+          },
+          rdap: {
+            checkedCount: 0,
+            totalCount: 0,
+            running: false,
+            errorKey: null
+          }
+        } satisfies AppState;
+      }
       case "input/clear": {
         if (state.input.domains.length === 0) {
           return state;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -225,6 +225,8 @@ export interface AppState {
 export type AppAction =
   | { type: "input/setDomains"; payload: { domains: DomainItem[] } }
   | { type: "input/appendDomains"; payload: { domains: DomainItem[] } }
+  | { type: "input/appendDomainBatch"; payload: { domains: DomainItem[] } }
+  | { type: "input/appendDomainBatchFinalize" }
   | { type: "input/clear" }
   | { type: "dns/start"; payload: { runId: number; total: number } }
   | { type: "dns/retry"; payload: { runId: number; total: number } }


### PR DESCRIPTION
## Summary
- refactor dictionary generation helpers into async generators that yield batches and expose progress feedback
- dispatch batched domain updates with new reducer actions while keeping DNS/RDAP state resets centralized
- add localized strings for the live progress indicator shown during long-running generations

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e22edec3748320bf1679d76c77b960