### PR TITLE
Fix WideShell layout overflow on small devices

### DIFF
--- a/src/layouts/WideShell.tsx
+++ b/src/layouts/WideShell.tsx
@@ -4,7 +4,6 @@ import Box from "@mui/material/Box";
 import Container from "@mui/material/Container";
 import Divider from "@mui/material/Divider";
 import Drawer from "@mui/material/Drawer";
-import Grid from "@mui/material/Grid";
 import IconButton from "@mui/material/IconButton";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
@@ -237,13 +236,25 @@ export default function WideShell({ children }: PropsWithChildren) {
               minHeight: 0
             }}
           >
-            <Grid container spacing={3} alignItems="flex-start" sx={{ flexGrow: 1 }}>
-              <Grid size={{ xs: 12, lg: 9 }} sx={{ minHeight: 0 }}>
+            <Box
+              sx={{
+                display: "grid",
+                gridTemplateColumns: {
+                  xs: "minmax(0, 1fr)",
+                  lg: "minmax(0, 3fr) minmax(0, 1fr)"
+                },
+                alignItems: "flex-start",
+                gap: 3,
+                flexGrow: 1,
+                minHeight: 0
+              }}
+            >
+              <Box sx={{ minHeight: 0 }}>
                 <Box sx={{ display: "flex", flexDirection: "column", gap: 3, minHeight: 0 }}>
                   {children}
                 </Box>
-              </Grid>
-              <Grid size={{ xs: 12, lg: 3 }} sx={{ minHeight: 0 }}>
+              </Box>
+              <Box sx={{ minHeight: 0 }}>
                 <Box
                   // 右侧栏在大屏保持可见，贴合原型要求
                   sx={{
@@ -256,8 +267,8 @@ export default function WideShell({ children }: PropsWithChildren) {
                 >
                   {sidebarContent ?? <DefaultSidebar />}
                 </Box>
-              </Grid>
-            </Grid>
+              </Box>
+            </Box>
           </Container>
         </Box>
       </Box>


### PR DESCRIPTION
## Summary
- replace the WideShell Grid container with a CSS grid to remove the negative margin overflow that pushed DNS/RDAP cards past the viewport on narrow screens
- keep the sidebar sticky behaviour while preserving the existing spacing between sections

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e39f6a76808320b2d4a11fed22063a